### PR TITLE
Fix: Remove unused joblib import

### DIFF
--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -2,7 +2,6 @@ import os
 import sys
 import logging
 import argparse
-import joblib
 import pandas as pd
 import numpy as np
 import mlflow


### PR DESCRIPTION
The 'joblib' library was imported in 'src/pipeline/training_pipeline.py' but was not being used, causing a linting error (F401) in the CI pipeline.

This commit removes the unused import statement to resolve the error.