### PR TITLE
Refactor configuration to use environment variables

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -14,6 +14,14 @@ jobs:
   test-and-lint:
     runs-on: ubuntu-latest
 
+    # Environment variables available to all steps in this job.
+    # We set these to ensure tests run with a consistent, isolated configuration.
+    env:
+      MINIO_CREDENTIALS_ENDPOINT_URL: "http://test-minio:9000"
+      MINIO_CREDENTIALS_BUCKET_NAME: "test-fraud-detection"
+      MLFLOW_CONFIG_TRACKING_URI: "http://test-mlflow:5000"
+      MLFLOW_CONFIG_EXPERIMENT_NAME: "Test-CI-Experiment"
+
     steps:
       - name: '✅ Checkout Repository'
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -73,6 +73,31 @@ This project provides a fully functional, end-to-end machine learning pipeline f
     ```
     For this project, ensure your MLflow tracking server is running and accessible. The default URI is `http://mlflow:5000`, which implies it's running in a Docker network.
 
+## Configuration Management
+
+This project uses a hierarchical configuration system that combines a YAML file with environment variables, providing flexibility for different deployment environments.
+
+1.  **Base Configuration (`config/config.yaml`):**
+    This file contains the default settings for the pipeline, such as data paths, artifact names, and feature definitions. These defaults are suitable for local development.
+
+2.  **Environment Variable Overrides:**
+    Any setting in `config.yaml` can be dynamically overridden using environment variables. This is the recommended way to configure the application for staging and production environments.
+
+    To override a setting, create an environment variable with a name derived from the YAML structure, converted to `UPPERCASE_SNAKE_CASE`.
+
+    **Example:**
+    To override the MLflow tracking URI, which is defined in the YAML as:
+    ```yaml
+    mlflow_config:
+      tracking_uri: "http://mlflow:5000"
+    ```
+    You would set the following environment variable:
+    ```bash
+    export MLFLOW_CONFIG_TRACKING_URI="http://your-production-mlflow-server:5000"
+    ```
+
+    This system allows you to keep secrets and environment-specific details out of version control, following security best practices. When running in Docker or a CI/CD pipeline, you can inject these environment variables to configure the application at runtime.
+
 ## How to Use the Pipeline
 
 ### 1. Run Data Analysis (Optional)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,23 +1,35 @@
 # config/config.yaml
+
+# Configuration for data paths. These are typically relative to the project root.
 data_source:
   raw_data_dir: "data/raw"
   processed_data_dir: "data/processed"
   raw_data_filename: "fraud_detection.csv"
 
+# --- Environment-Specific Configurations ---
+# The values below are defaults for local development.
+# They can be overridden by setting the corresponding environment variables.
+# For example, to override the MinIO endpoint URL, set the
+# MINIO_CREDENTIALS_ENDPOINT_URL environment variable.
+
 minio_credentials:
+  # Default for local Docker Compose setup. Override for other environments.
   endpoint_url: "http://minio:9000"
   bucket_name: "fraud-detection"
 
 mlflow_config:
+  # Default for local Docker Compose setup. Override for other environments.
   tracking_uri: "http://mlflow:5000"
-  experiment_name: "Fraud-Detection-Experiments" # More generic name
-  registered_model_base_name: "FraudDetector" # Base name for registration
+  experiment_name: "Fraud-Detection-Experiments"
+  registered_model_base_name: "FraudDetector"
 
+# Configuration for artifacts generated during the pipeline.
 artifacts:
   preprocessor_name: "preprocessor.joblib"
   processed_train_name: "train.csv"
   processed_test_name: "test.csv"
 
+# Feature engineering configuration.
 features:
   target_column: "label"
   numerical_cols:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,18 +1,56 @@
 # src/utils.py
 import yaml
 import logging
+import os
+
+def _get_env_var_name(path_keys):
+    """Converts a list of dictionary keys to an uppercase, underscore-separated env var name."""
+    return "_".join(path_keys).upper()
+
+def _override_with_env_vars(config, path_keys=[]):
+    """
+    Recursively traverses the config dict and overrides values with
+    corresponding environment variables.
+    """
+    for key, value in config.items():
+        current_path_keys = path_keys + [key]
+        if isinstance(value, dict):
+            _override_with_env_vars(value, current_path_keys)
+        else:
+            env_var_name = _get_env_var_name(current_path_keys)
+            env_var_value = os.getenv(env_var_name)
+            if env_var_value:
+                # Try to cast env var to the same type as the original value
+                try:
+                    original_type = type(value)
+                    config[key] = original_type(env_var_value)
+                    logging.info(f"Overrode '{'.'.join(current_path_keys)}' with env var '{env_var_name}'.")
+                except (ValueError, TypeError):
+                    config[key] = env_var_value # Fallback to string
+                    logging.warning(f"Could not cast env var '{env_var_name}' to type {original_type}. Using as string.")
+
 
 def load_config(path="config/config.yaml"):
-    """Loads a YAML configuration file."""
+    """
+    Loads a YAML configuration file and allows environment variables to override its values.
+
+    For a nested key like `minio_credentials.endpoint_url`, the corresponding
+    environment variable would be `MINIO_CREDENTIALS_ENDPOINT_URL`.
+    """
     try:
         with open(path, 'r') as f:
-            return yaml.safe_load(f)
+            config = yaml.safe_load(f)
     except FileNotFoundError:
         logging.error(f"Configuration file not found at {path}")
         raise
     except Exception as e:
-        logging.error(f"Error loading configuration: {e}")
+        logging.error(f"Error loading YAML configuration: {e}")
         raise
+
+    # Override with environment variables
+    _override_with_env_vars(config)
+
+    return config
 
 def load_params(path="params.yaml"):
     """Loads a YAML parameters file."""


### PR DESCRIPTION
This commit refactors the configuration management system to allow for environment variables to override the values in the `config.yaml` file. This makes the application more flexible and secure, as it allows for different configurations in different environments (e.g., local, staging, production) without changing the code.

The following changes were made:

- Modified `src/utils.py` to recursively read the configuration and override values with environment variables.
- Updated `config/config.yaml` with default values and comments to explain the new system.
- Updated the CI/CD pipeline to inject test-specific configurations using environment variables.
- Added documentation for the new configuration system to `README.md`.