### PR TITLE
fix(docker): Use --without dev instead of --no-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY pyproject.toml poetry.lock ./
 # Install project dependencies using Poetry.
 # --no-root: Don't install the project package itself yet.
 # --no-dev: Exclude development dependencies (e.g., testing libraries).
-RUN poetry install --no-root --no-dev
+RUN poetry install --no-root --without dev
 
 # --- Final Stage ---
 # This stage builds the final, runnable image.


### PR DESCRIPTION
The --no-dev flag is deprecated in newer versions of poetry. This commit updates the Dockerfile to use the correct --without dev flag to exclude development dependencies during the build process. This resolves the release pipeline failure.