### PR TITLE
fix(docker): Configure poetry to create venv in project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,13 @@ RUN pip install poetry
 # Copy only the dependency definition files.
 COPY pyproject.toml poetry.lock ./
 
+# Configure Poetry to create the virtual environment in the project's root.
+RUN poetry config virtualenvs.in-project true --local
+
 # Install project dependencies using Poetry.
 # --no-root: Don't install the project package itself yet.
 # --no-dev: Exclude development dependencies (e.g., testing libraries).
-RUN poetry install --no-root --no-dev
+RUN poetry install --no-root --without dev
 
 # --- Final Stage ---
 # This stage builds the final, runnable image.


### PR DESCRIPTION
The previous fix corrected the poetry install command, but the build still failed because poetry was creating the virtual environment in its default cache directory.

This commit adds a command to configure poetry to create the virtual environment within the project's root directory (`.venv`). This ensures the `COPY --from=builder /app/.venv /app/.venv` command can find the virtual environment and the Docker build can complete successfully.