### PR TITLE
The Docker build was failing with a `chmod: operation not permitted` …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ USER appuser
 # ENV MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
 
 # Copy the entrypoint script and make it executable
-COPY scripts/entrypoint.sh /app/scripts/entrypoint.sh
+COPY --chown=appuser:appgroup scripts/entrypoint.sh /app/scripts/entrypoint.sh
 RUN chmod +x /app/scripts/entrypoint.sh
 
 # Define the entrypoint for the container.


### PR DESCRIPTION
…error when trying to make the `entrypoint.sh` script executable.

This was caused by the `entrypoint.sh` file being copied into the container with `root` ownership after the user was switched to a non-root user (`appuser`). The non-root user did not have permission to change the mode of the root-owned file.

I have fixed this by adding the `--chown=appuser:appgroup` flag to the `COPY` command in the `Dockerfile`. This ensures the file is owned by `appuser`, which can then successfully make it executable.