### PR TITLE
fix: Install libgomp1 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@
 # Use a slim Python base image for a smaller final image size.
 FROM python:3.10-slim AS base
 
+# Install essential libraries for LightGBM.
+RUN apt-get update && apt-get install -y --no-install-recommends libgomp1
+
 # Set environment variables to prevent Python from writing .pyc files and buffering output.
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
The release pipeline was failing with an `OSError: libgomp.so.1: cannot open shared object file: No such file or directory`. This error is caused by a missing shared library dependency for LightGBM.

This commit fixes the issue by adding a `RUN` command to the `Dockerfile` to install the `libgomp1` package, which provides the required `libgomp.so.1` library. The installation is done in the `base` stage to ensure the library is available in the final runtime environment.