### PR TITLE
feat: Add basic authentication to MLflow server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,8 @@ MLFLOW_DB_PASSWORD=mlflow_pass
 # --- MinIO Credentials for Artifact Store ---
 MINIO_ACCESS_KEY_ID=minio_access_key
 MINIO_SECRET_KEY=minio_secret_key
+
+# --- MLflow Basic Auth Credentials ---
+MLFLOW_TRACKING_USERNAME=mlflow_user
+MLFLOW_TRACKING_PASSWORD=mlflow_password
+MLFLOW_FLASK_SECRET_KEY=my_super_secret_key

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,7 +9,7 @@ minio_credentials:
   bucket_name: "mlflow"
 
 mlflow_config:
-  tracking_uri: "${MLFLOW_TRACKING_URI}"
+  tracking_uri: "http://127.0.0.1:5000"
   experiment_name: "Fraud-Detection-Experiments" # More generic name
   registered_model_base_name: "FraudDetector" # Base name for registration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - MLFLOW_DB_PASSWORD=${MLFLOW_DB_PASSWORD:-mlflow_pass}
       - MINIO_ACCESS_KEY_ID=${MINIO_ACCESS_KEY_ID:-minio_access_key}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-minio_secret_key}
+      - MLFLOW_FLASK_SECRET_KEY=${MLFLOW_FLASK_SECRET_KEY:-my_secret_key}
     depends_on:
       mlflow-db:
         condition: service_healthy
@@ -54,7 +55,7 @@ services:
         condition: service_healthy
     command: >
       bash -c "
-        pip install mlflow psycopg2-binary boto3 &&
+        pip install mlflow[auth] psycopg2-binary boto3 &&
         # Create MinIO bucket if it doesn't exist
         pip install mc &&
         mc alias set minio http://minio:9000 ${MINIO_ACCESS_KEY_ID:-minio_access_key} ${MINIO_SECRET_KEY:-minio_secret_key} &&
@@ -64,6 +65,7 @@ services:
         --backend-store-uri postgresql://${MLFLOW_DB_USER:-mlflow_user}:${MLFLOW_DB_PASSWORD:-mlflow_pass}@mlflow-db:5432/${MLFLOW_DB_NAME:-mlflow_db}
         --default-artifact-root s3://mlflow
         --host 0.0.0.0
+        --app-name basic-auth
       "
 
 volumes:


### PR DESCRIPTION
This commit enables basic authentication for the MLflow server.

- Modified `docker-compose.yml` to:
  - Install `mlflow[auth]`
  - Add the `--app-name basic-auth` flag to the `mlflow server` command
  - Add the `MLFLOW_FLASK_SECRET_KEY` environment variable
- Added `MLFLOW_TRACKING_USERNAME`, `MLFLOW_TRACKING_PASSWORD`, and `MLFLOW_FLASK_SECRET_KEY` to `.env.example`.
- Updated the `tracking_uri` in `config/config.yaml` to point to the local server.