### PR TITLE
fix(ci): add mlflow authentication to release pipeline

### DIFF
--- a/.github/workflows/release-triggered-training.yaml
+++ b/.github/workflows/release-triggered-training.yaml
@@ -12,6 +12,8 @@ jobs:
     
     env:
       MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
+      MLFLOW_TRACKING_USERNAME: ${{ secrets.MLFLOW_TRACKING_USERNAME }}
+      MLFLOW_TRACKING_PASSWORD: ${{ secrets.MLFLOW_TRACKING_PASSWORD }}
       AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
       MLFLOW_S3_ENDPOINT_URL: ${{ secrets.MINIO_ENDPOINT_URL }}
@@ -38,6 +40,8 @@ jobs:
           # 3. Run the Docker container, passing secrets and arguments
           docker run --rm \
             -e MLFLOW_TRACKING_URI \
+            -e MLFLOW_TRACKING_USERNAME \
+            -e MLFLOW_TRACKING_PASSWORD \
             -e AWS_ACCESS_KEY_ID \
             -e AWS_SECRET_ACCESS_KEY \
             -e MLFLOW_S3_ENDPOINT_URL \


### PR DESCRIPTION
The release-triggered training pipeline was failing with a 401 Unauthorized error from the MLflow server. This was because the MLflow server is configured to use basic authentication, but the pipeline was not providing any credentials.

This change updates the GitHub Actions workflow to pass the `MLFLOW_TRACKING_USERNAME` and `MLFLOW_TRACKING_PASSWORD` environment variables (from repository secrets) to the training container.