### PR TITLE
Refactor: Decouple hyperparameter tuning from the release pipeline

### DIFF
--- a/.github/workflows/release-triggered-training.yaml
+++ b/.github/workflows/release-triggered-training.yaml
@@ -46,7 +46,7 @@ jobs:
             -e AWS_SECRET_ACCESS_KEY \
             -e MLFLOW_S3_ENDPOINT_URL \
             fraud-detection-pipeline \
-            --model "$MODEL_NAME" --tune
+            --model "$MODEL_NAME" --use-best-params
           
       - name: '🎉 Training Complete'
         run: echo "Model training and registration complete. Check your MLflow UI."

--- a/params.yaml
+++ b/params.yaml
@@ -54,3 +54,19 @@ tuning:
       classifier__n_estimators: [50, 100]
       classifier__max_depth: [3, 5]
       classifier__learning_rate: [0.05, 0.1]
+
+# --- Best Hyperparameters (to be updated after tuning) ---
+best_params:
+  xgboost:
+    n_estimators: 150
+    max_depth: 5
+    learning_rate: 0.1
+
+  lightgbm:
+    n_estimators: 200
+    learning_rate: 0.05
+    num_leaves: 31
+
+  logistic_regression:
+    solver: 'liblinear'
+    C: 1.0


### PR DESCRIPTION
This change addresses a bottleneck in the release process where expensive hyperparameter tuning was performed on every release.

The key changes are:

1.  Introduced a `--use-best-params` flag to the training pipeline. This allows the pipeline to run with a pre-defined, optimal set of hyperparameters, making it fast and deterministic.

2.  Added a `best_params` section to `params.yaml` to store these version-controlled hyperparameters. This section is populated with initial defaults and is intended to be updated by data scientists after offline tuning experiments.

3.  Updated the `TrainingPipeline` logic to use these best parameters when the new flag is specified. This includes updating MLflow run names and tags for better tracking.

4.  Modified the `.github/workflows/release-triggered-training.yaml` to replace the `--tune` flag with `--use-best-params`, ensuring the release pipeline is now lean and efficient.

The `--tune` flag is still available for developers to run tuning manually or in separate, dedicated workflows.