### PR TITLE
Handle $VAR style environment placeholders

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+# Add src to path to allow imports
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from src.utils import _replace_env_vars
+
+
+def test_replace_env_vars_handles_both_styles(monkeypatch):
+    monkeypatch.setenv('TEST_VAR', 'value')
+    original = 'path:${TEST_VAR}/$TEST_VAR'
+    replaced = _replace_env_vars(original)
+    assert replaced == 'path:value/value'


### PR DESCRIPTION
## Summary
- extend environment variable substitution to support `$VAR` placeholders in config strings
- add test to ensure both `${VAR}` and `$VAR` formats are replaced

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68970e2eaf48832d90bb3f90d19daf35