### PR TITLE
Use 'categorical' key for feature importance logging

### DIFF
--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -307,11 +307,11 @@ class TrainingPipeline:
             preprocessor = pipeline.named_steps['preprocessor']
 
             # Get feature names after one-hot encoding
-            cat_features = preprocessor.named_transformers_['cat'].get_feature_names_out(
+            categorical_features = preprocessor.named_transformers_['categorical'].get_feature_names_out(
                 self.config['features']['categorical_cols']
             )
             num_features = self.config['features']['numerical_cols']
-            feature_names = np.concatenate([num_features, cat_features])
+            feature_names = np.concatenate([num_features, categorical_features])
 
             importances = classifier.feature_importances_
 


### PR DESCRIPTION
## Summary
- Fix feature importance logging to use `categorical` transformer key

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897106b81ac832db918230100aaea1b