### PR TITLE
Remove unused pytest import in data transformation tests

### DIFF
--- a/tests/test_data_transformation.py
+++ b/tests/test_data_transformation.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import numpy as np
-import pytest
 from sklearn.compose import ColumnTransformer
 from sklearn.pipeline import Pipeline
 


### PR DESCRIPTION
## Summary
- remove unused pytest import from `tests/test_data_transformation.py`

## Testing
- `poetry run ruff check .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689712834c70832d9117896d93bc610c