### PR TITLE
feat: drop constant features

### DIFF
--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -22,7 +22,7 @@ from sklearn.metrics import make_scorer, f1_score, precision_score, recall_score
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from src.components.data_transformation import DataTransformation
 from src.components.model_trainer import ModelTrainer
-from src.utils import load_config, load_params
+from src.utils import load_config, load_params, drop_constant_columns
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
@@ -140,6 +140,12 @@ class TrainingPipeline:
 
             # --- 1. Load Data ---
             df = self._load_data()
+            feature_cols = self.config['features']['numerical_cols'] + self.config['features']['categorical_cols']
+            df, dropped = drop_constant_columns(df, feature_cols)
+            if dropped:
+                logging.warning(f"Dropping constant features: {dropped}")
+                self.config['features']['numerical_cols'] = [c for c in self.config['features']['numerical_cols'] if c not in dropped]
+                self.config['features']['categorical_cols'] = [c for c in self.config['features']['categorical_cols'] if c not in dropped]
             X = df.drop(columns=[self.config['features']['target_column']])
             y = df[self.config['features']['target_column']]
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,6 +3,9 @@ import os
 import yaml
 import logging
 import re
+from typing import List, Tuple
+
+import pandas as pd
 from dotenv import load_dotenv
 
 def _replace_env_vars(config_str: str) -> str:
@@ -58,3 +61,17 @@ def load_params(path="params.yaml"):
     except Exception as e:
         logging.error(f"Error loading parameters: {e}")
         raise
+
+
+def drop_constant_columns(df: pd.DataFrame, columns: List[str]) -> Tuple[pd.DataFrame, List[str]]:
+    """Removes columns with zero variance from a DataFrame.
+
+    Args:
+        df: Input DataFrame.
+        columns: Columns to check for constancy.
+
+    Returns:
+        A tuple of the cleaned DataFrame and a list of columns that were dropped.
+    """
+    dropped = [col for col in columns if col in df.columns and df[col].nunique(dropna=False) <= 1]
+    return df.drop(columns=dropped), dropped

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,11 @@
 import os
 import sys
 
+import pandas as pd
+
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
-from src.utils import _replace_env_vars
+from src.utils import _replace_env_vars, drop_constant_columns
 
 
 def test_replace_env_vars_handles_both_styles(monkeypatch):
@@ -12,3 +14,10 @@ def test_replace_env_vars_handles_both_styles(monkeypatch):
     original = 'path:${TEST_VAR}/$TEST_VAR'
     replaced = _replace_env_vars(original)
     assert replaced == 'path:value/value'
+
+
+def test_drop_constant_columns():
+    df = pd.DataFrame({'a': [1, 1, 1], 'b': [1, 2, 3]})
+    cleaned, dropped = drop_constant_columns(df, ['a', 'b'])
+    assert dropped == ['a']
+    assert list(cleaned.columns) == ['b']


### PR DESCRIPTION
## Summary
- drop constant features before model training
- add utility for constant feature removal
- test constant column detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689732f11900832d8b197f94c54e5cca