### PR TITLE
feat: update tuned xgboost parameters

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -61,9 +61,9 @@ tuning:
 # --- Best Hyperparameters (to be updated after tuning) ---
 best_params:
   xgboost:
-    n_estimators: 150
-    max_depth: 5
-    learning_rate: 0.1
+    n_estimators: 50
+    max_depth: 3
+    learning_rate: 0.05
 
   lightgbm:
     n_estimators: 200


### PR DESCRIPTION
## Summary
- update best XGBoost tuned parameters

## Testing
- `pytest` *(fails: AttributeError: 'ModelInfo' object has no attribute 'version')*


------
https://chatgpt.com/codex/tasks/task_e_68985ab0e778832d8e2ef8bb8bf84c1c