### PR TITLE
refactor: centralize copy import

### DIFF
--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -2,6 +2,7 @@ import os
 import sys
 import logging
 import argparse
+import copy
 import pandas as pd
 import numpy as np
 import mlflow
@@ -152,7 +153,6 @@ class TrainingPipeline:
     def run(self):
         """Execute the full training or tuning pipeline."""
         try:
-            import copy
             params_for_run = copy.deepcopy(self.params)
 
             if self.use_best_params:


### PR DESCRIPTION
## Summary
- import copy at module level in training pipeline
- drop redundant inline import in TrainingPipeline.run

## Testing
- `pip install pandas numpy scikit-learn imbalanced-learn mlflow boto3 matplotlib seaborn joblib marshmallow pyyaml`
- `pip install xgboost lightgbm python-dotenv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988fb03eb8832db4fc43c1f26eca0e