### PR TITLE
Switch to MLflow model aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ The training pipeline is designed to be run inside its Docker container to ensur
 
 Use `src/predict.py` to make predictions with a model from the MLflow Model Registry.
 ```bash
-# Example: Make predictions with the 'Staging' version of the xgboost model
+# Example: Make predictions with the 'champion' alias of the xgboost model
 poetry run python src/predict.py \
   --model xgboost \
-  --stage Staging \
+  --alias champion \
   --input "path/to/your/data.csv" \
   --output "predictions.csv"
 ```

--- a/src/components/model_trainer.py
+++ b/src/components/model_trainer.py
@@ -1,7 +1,5 @@
 import logging
 import numpy as np
-from xgboost import XGBClassifier
-from lightgbm import LGBMClassifier
 from sklearn.linear_model import LogisticRegression
 
 class ModelTrainer:
@@ -31,6 +29,8 @@ class ModelTrainer:
         model_params = self.params.get(self.model_name, {}).copy()
 
         if self.model_name == "xgboost":
+            from xgboost import XGBClassifier
+
             if self.handle_imbalance and y_train is not None:
                 neg_count = np.sum(y_train == 0)
                 pos_count = np.sum(y_train == 1)
@@ -41,6 +41,8 @@ class ModelTrainer:
             return XGBClassifier(random_state=self.random_state, **model_params)
 
         elif self.model_name == "lightgbm":
+            from lightgbm import LGBMClassifier
+
             if not self.handle_imbalance and 'is_unbalance' in model_params:
                 del model_params['is_unbalance']
             return LGBMClassifier(random_state=self.random_state, **model_params)

--- a/tests/test_inference_pipeline.py
+++ b/tests/test_inference_pipeline.py
@@ -58,17 +58,17 @@ def test_inference_pipeline(tmp_path):
             registered_model = (
                 f"{config['mlflow_config']['registered_model_base_name']}-logistic_regression"
             )
-            model_version = client.get_latest_versions(
-                registered_model, stages=["Staging"]
-            )[0]
-            assert model_version.current_stage == "Staging"
+            model_version = client.get_model_version_by_alias(
+                registered_model, "champion"
+            )
+            assert "champion" in model_version.aliases
 
             predict_input = tmp_path / "predict_input.csv"
             df.drop(columns=["label"]).to_csv(predict_input, index=False)
             predict_output = tmp_path / "predict_output.csv"
             predict(
                 model_name="logistic_regression",
-                stage="Staging",
+                alias="champion",
                 input_path=str(predict_input),
                 output_path=str(predict_output),
             )


### PR DESCRIPTION
## Summary
- register trained models using MLflow aliases instead of stages
- load models for inference by alias and expose `--alias` CLI flags
- lazily import xgboost and lightgbm to avoid heavy dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a1e92070832d9382f4f4f699ddc2