### PR TITLE
docs: update Python version requirement to 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ This project provides a fully functional, end-to-end machine learning pipeline f
 ### Prerequisites
 
 - Docker & Docker Compose
-- Python 3.10+
+- Python 3.11+
+  - If needed, install it using a version manager such as [pyenv](https://github.com/pyenv/pyenv):
+    ```bash
+    pyenv install 3.11
+    pyenv global 3.11
+    ```
 - Poetry (`pip install poetry`)
 
 ### Setup Instructions


### PR DESCRIPTION
## Summary
- require Python 3.11+ in README
- add note on installing Python 3.11 with pyenv

## Testing
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_689a0d22eeac832dbcbb886ea1b1945a