### PR TITLE
feat: update base image to python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # --- Base Stage ---
 # Use a slim Python base image for a smaller final image size.
-FROM python:3.10-slim AS base
+FROM python:3.11-slim AS base
 
 # Install essential libraries for LightGBM.
 RUN apt-get update && apt-get install -y --no-install-recommends libgomp1


### PR DESCRIPTION
## Summary
- switch Docker base image to `python:3.11-slim`

## Testing
- `docker build -t fraud-detection-ml:latest .` *(fails: Cannot connect to the Docker daemon)*
- `docker run --rm fraud-detection-ml:latest --help` *(fails: Cannot connect to the Docker daemon)*
- `pytest` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_689a0d21ebb8832dbeca06243749c641