### PR TITLE
Update MLflow server to Python 3.11 base image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       retries: 5
 
   mlflow-server:
-    image: python:3.10-slim
+    image: python:3.11-slim
     container_name: mlflow-server
     ports:
       - "5000:5000"


### PR DESCRIPTION
## Summary
- Use Python 3.11 slim image for the mlflow-server service in docker-compose

## Testing
- `pytest` *(fails: No module named 'seaborn')*
- `docker-compose up --build mlflow-server` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689a0d2017c0832d809f7e00c552ff51