### PR TITLE
Handle unfitted preprocessors in feature name extraction

### DIFF
--- a/src/components/data_transformation.py
+++ b/src/components/data_transformation.py
@@ -60,6 +60,12 @@ class DataTransformation:
 
     def get_feature_names(self) -> List[str]:
         """Returns the feature names after transformation."""
+        if not hasattr(self.preprocessor, "named_transformers_"):
+            raise AttributeError(
+                "Preprocessor has not been fitted yet. Call fit or fit_transform before "
+                "retrieving feature names."
+            )
+
         try:
             numeric_features = self.config['numerical_cols']
             categorical_features_raw = self.config['categorical_cols']

--- a/tests/test_data_transformation.py
+++ b/tests/test_data_transformation.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 from sklearn.compose import ColumnTransformer
 from sklearn.pipeline import Pipeline
+import pytest
 
 # Add src to path to allow imports
 import sys
@@ -103,3 +104,12 @@ def test_transformation_on_sample_data():
         'device_type_mobile',
     ]
     assert transformer.get_feature_names() == expected_features
+
+
+def test_get_feature_names_without_fit_raises_error():
+    transformer = DataTransformation(
+        feature_config=SAMPLE_FEATURE_CONFIG,
+        params=SAMPLE_PARAMS,
+    )
+    with pytest.raises(AttributeError):
+        transformer.get_feature_names()


### PR DESCRIPTION
## Summary
- Ensure `get_feature_names` verifies the preprocessor is fitted before accessing encoder attributes
- Add unit test for calling `get_feature_names` without fitting

## Testing
- `ruff check src tests`
- `pytest tests/test_data_transformation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a1d642e88832d998bb1afc391343d