### PR TITLE
Move logging setup to entry points

### DIFF
--- a/notebooks/run_eda.py
+++ b/notebooks/run_eda.py
@@ -10,8 +10,6 @@ import seaborn as sns
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from src.utils import load_config
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 def run_analysis():
     """
     Performs and saves an exploratory data analysis of the dataset.
@@ -87,4 +85,5 @@ def run_analysis():
         raise
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
     run_analysis()

--- a/scripts/monitor_drift.py
+++ b/scripts/monitor_drift.py
@@ -9,8 +9,6 @@ import os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from src.utils import load_config
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 def run_drift_analysis(reference_df: pd.DataFrame, current_df: pd.DataFrame, config: dict):
     """
     Performs drift analysis between a reference and current dataset.
@@ -63,6 +61,8 @@ def run_drift_analysis(reference_df: pd.DataFrame, current_df: pd.DataFrame, con
     return drift_report
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
     parser = argparse.ArgumentParser(description="Monitor data drift between two datasets.")
     parser.add_argument(
         "--reference_data",

--- a/src/components/data_transformation.py
+++ b/src/components/data_transformation.py
@@ -7,8 +7,6 @@ from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler, FunctionTransformer
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 class DataTransformation:
     """Handles feature engineering and preprocessing based on configuration."""
 

--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -26,8 +26,6 @@ from src.components.data_transformation import DataTransformation
 from src.components.model_trainer import ModelTrainer
 from src.utils import load_config, load_params, drop_constant_columns
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 class TrainingPipeline:
     def __init__(self, model_name: str, tune: bool, use_best_params: bool = False, tune_and_evaluate: bool = False, model_alias: str | None = None):
         self.model_name = model_name
@@ -383,6 +381,8 @@ class TrainingPipeline:
             logging.warning(f"Could not generate or log feature importance plot: {e}")
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
     parser = argparse.ArgumentParser(description="Run the ML training pipeline.")
     parser.add_argument(
         "--model",

--- a/src/predict.py
+++ b/src/predict.py
@@ -9,8 +9,6 @@ import mlflow
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from src.utils import load_config
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 def predict(model_name: str, alias: str, input_path: str, output_path: str):
     """Load a registered model from MLflow and generate predictions.
 
@@ -57,6 +55,8 @@ def predict(model_name: str, alias: str, input_path: str, output_path: str):
         raise
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
     parser = argparse.ArgumentParser(description="Make predictions using a registered model.")
     parser.add_argument(
         "--model",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import logging
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Summary
- avoid configuring logging in reusable modules
- configure logging in script entry points
- ensure tests set up logging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a1d61f98c832d98584397dc93f6c0