### PR TITLE
Fix feature name extraction for categorical pipeline

### DIFF
--- a/src/components/data_transformation.py
+++ b/src/components/data_transformation.py
@@ -69,8 +69,12 @@ class DataTransformation:
             categorical_features_raw = self.config['categorical_cols']
 
             # Get feature names from the one-hot encoder
-            onehot_transformer = self.preprocessor.named_transformers_['categorical']['onehot']
-            categorical_features_encoded = onehot_transformer.get_feature_names_out(categorical_features_raw).tolist()
+            onehot_transformer = (
+                self.preprocessor.named_transformers_['categorical'].named_steps['onehot']
+            )
+            categorical_features_encoded = (
+                onehot_transformer.get_feature_names_out(categorical_features_raw).tolist()
+            )
 
             return numeric_features + categorical_features_encoded
         except Exception as e:


### PR DESCRIPTION
## Summary
- Access one-hot encoder via `named_steps` in data transformation to properly retrieve categorical feature names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c326a1cf8832da8a68826cfea33e2