### PR TITLE
Pin MLflow auth version in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
         condition: service_healthy
     command: >
       bash -c "
-        pip install mlflow[auth]==3.* psycopg2-binary boto3 &&
+        pip install mlflow[auth]==2.10.2 psycopg2-binary boto3 &&
         # Create MinIO bucket if it doesn't exist
         pip install mc &&
         mc alias set minio http://minio:9000 ${MINIO_ACCESS_KEY_ID:-minio_access_key} ${MINIO_SECRET_KEY:-minio_secret_key} &&


### PR DESCRIPTION
## Summary
- pin `mlflow[auth]` to v2.10.2 for the mlflow server image

## Testing
- `pytest`
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c32694150832d9ae3328ad6612a42