### PR TITLE
Remove deprecated XGBoost label encoder parameter

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -19,7 +19,6 @@ xgboost:
   learning_rate: 0.1
   objective: 'binary:logistic'
   eval_metric: 'aucpr'
-  use_label_encoder: False
   # scale_pos_weight is calculated dynamically in the trainer
 
 lightgbm:


### PR DESCRIPTION
## Summary
- drop `use_label_encoder` from XGBoost hyperparameters

## Testing
- `poetry run python src/pipeline/training_pipeline.py --model xgboost`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c32692e0c832da34260c6933df07c