### PR TITLE
Configure MLflow to use MinIO via AWS env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ MLFLOW_DB_PASSWORD=mlflow_pass
 # --- MinIO Credentials for Artifact Store ---
 MINIO_ACCESS_KEY_ID=minio_access_key
 MINIO_SECRET_KEY=minio_secret_key
+MLFLOW_S3_ENDPOINT_URL=http://minio:9000
 
 # --- MLflow Basic Auth Credentials ---
 MLFLOW_TRACKING_USERNAME=mlflow_user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,9 @@ services:
       - MLFLOW_DB_PASSWORD=${MLFLOW_DB_PASSWORD:-mlflow_pass}
       - MINIO_ACCESS_KEY_ID=${MINIO_ACCESS_KEY_ID:-minio_access_key}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-minio_secret_key}
+      - AWS_ACCESS_KEY_ID=${MINIO_ACCESS_KEY_ID:-minio_access_key}
+      - AWS_SECRET_ACCESS_KEY=${MINIO_SECRET_KEY:-minio_secret_key}
+      - MLFLOW_S3_ENDPOINT_URL=http://minio:9000
       - MLFLOW_FLASK_SECRET_KEY=${MLFLOW_FLASK_SECRET_KEY:-my_secret_key}
     depends_on:
       mlflow-db:


### PR DESCRIPTION
## Summary
- expose MinIO credentials to MLflow via AWS-style environment variables
- document S3 endpoint in env example for easier configuration

## Testing
- `pytest -q -o addopts=""` *(fails: ModuleNotFoundError: No module named 'mlflow', 'numpy', 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_689c71c2412c832db142ff7cc042c513