### PR TITLE
Use mlflow.config.set_registry_uri

### DIFF
--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -108,7 +108,7 @@ class TrainingPipeline:
 
         self._ensure_mlflow_bucket_exists()
         mlflow.set_tracking_uri(self.mlflow_config['tracking_uri'])
-        mlflow.set_registry_uri(self.registry_uri)
+        mlflow.config.set_registry_uri(self.registry_uri)
         mlflow.set_experiment(self.mlflow_config['experiment_name'])
 
         # Start the parent run

--- a/src/predict.py
+++ b/src/predict.py
@@ -26,7 +26,7 @@ def predict(model_name: str, alias: str, input_path: str, output_path: str):
         mlflow_config = config['mlflow_config']
         registry_uri = mlflow_config.get('registry_uri', mlflow_config['tracking_uri'])
         mlflow.set_tracking_uri(mlflow_config['tracking_uri'])
-        mlflow.set_registry_uri(registry_uri)
+        mlflow.config.set_registry_uri(registry_uri)
 
         # Resolve the alias to a concrete model version
         registered_model_name = (

--- a/tests/mlflow_compat_test.py
+++ b/tests/mlflow_compat_test.py
@@ -21,7 +21,7 @@ def mlflow_client(tmpdir_factory):
     tracking_uri = f"sqlite:///{tmp_path}/mlflow.db"
     mlflow.set_tracking_uri(tracking_uri)
     # Set both tracking and registry URIs for consistency
-    mlflow.set_registry_uri(tracking_uri)
+    mlflow.config.set_registry_uri(tracking_uri)
     return MlflowClient(tracking_uri=tracking_uri, registry_uri=tracking_uri)
 
 def test_mlflow_end_to_end_roundtrip(mlflow_client):

--- a/tests/test_inference_pipeline.py
+++ b/tests/test_inference_pipeline.py
@@ -42,7 +42,7 @@ def test_inference_pipeline(tmp_path):
             os.environ["MLFLOW_TRACKING_URI"] = tracking_uri
             os.environ["MLFLOW_REGISTRY_URI"] = tracking_uri
             mlflow.set_tracking_uri(tracking_uri)
-            mlflow.set_registry_uri(tracking_uri)
+            mlflow.config.set_registry_uri(tracking_uri)
 
             config = load_config()
             experiment_name = config["mlflow_config"]["experiment_name"]


### PR DESCRIPTION
## Summary
- switch to `mlflow.config.set_registry_uri` in training and inference logic
- update tests to use the new MLflow registry configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mlflow')*


------
https://chatgpt.com/codex/tasks/task_e_689c71bfc384832da7d344612247dd0a