### PR TITLE
feat: centralize MinIO endpoint variable

### DIFF
--- a/.github/workflows/release-triggered-training.yaml
+++ b/.github/workflows/release-triggered-training.yaml
@@ -16,7 +16,7 @@ jobs:
       MLFLOW_TRACKING_PASSWORD: ${{ secrets.MLFLOW_TRACKING_PASSWORD }}
       AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
-      MLFLOW_S3_ENDPOINT_URL: ${{ secrets.MINIO_ENDPOINT_URL }}
+      MLFLOW_S3_ENDPOINT_URL: ${{ secrets.MLFLOW_S3_ENDPOINT_URL }}
 
     steps:
       - name: '✅ Checkout Repository'

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The training pipeline is designed to be run inside its Docker container to ensur
 
     docker run --rm --network="host" \
       -e MLFLOW_TRACKING_URI="http://localhost:5000" \
-      -e MINIO_ENDPOINT_URL="http://localhost:9000" \
+      -e MLFLOW_S3_ENDPOINT_URL="http://localhost:9000" \
       -e AWS_ACCESS_KEY_ID=$(grep MINIO_ACCESS_KEY_ID .env | cut -d '=' -f2) \
       -e AWS_SECRET_ACCESS_KEY=$(grep MINIO_SECRET_KEY .env | cut -d '=' -f2) \
       fraud-detection-pipeline \
@@ -124,7 +124,7 @@ The training pipeline is designed to be run inside its Docker container to ensur
     ```bash
     docker run --rm --network="host" \
       -e MLFLOW_TRACKING_URI="http://localhost:5000" \
-      -e MINIO_ENDPOINT_URL="http://localhost:9000" \
+      -e MLFLOW_S3_ENDPOINT_URL="http://localhost:9000" \
       -e AWS_ACCESS_KEY_ID=$(grep MINIO_ACCESS_KEY_ID .env | cut -d '=' -f2) \
       -e AWS_SECRET_ACCESS_KEY=$(grep MINIO_SECRET_KEY .env | cut -d '=' -f2) \
       fraud-detection-pipeline \

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,7 +5,7 @@ data_source:
   raw_data_filename: "fraud_detection.csv"
 
 minio_credentials:
-  endpoint_url: "${MINIO_ENDPOINT_URL}"
+  endpoint_url: "${MLFLOW_S3_ENDPOINT_URL}"
   bucket_name: "mlflow"
 
 mlflow_config:

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Ensure the MinIO endpoint is available to all subprocesses
+export MLFLOW_S3_ENDPOINT_URL
+
 # Configure DVC with credentials from environment variables
 dvc remote modify minio endpointurl ${MLFLOW_S3_ENDPOINT_URL}
 dvc remote modify minio access_key_id ${AWS_ACCESS_KEY_ID}

--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -57,7 +57,10 @@ class TrainingPipeline:
 
     def _ensure_mlflow_bucket_exists(self):
         """Checks if the MLflow artifact bucket exists in MinIO/S3 and creates it if not."""
-        endpoint_url = os.getenv("MLFLOW_S3_ENDPOINT_URL")
+        endpoint_url = self.config['minio_credentials'].get('endpoint_url')
+        if not endpoint_url or endpoint_url.startswith("$"):
+            endpoint_url = os.getenv("MLFLOW_S3_ENDPOINT_URL")
+
         access_key = os.getenv("AWS_ACCESS_KEY_ID")
         secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
         bucket_name = self.config['minio_credentials']['bucket_name']


### PR DESCRIPTION
## Summary
- unify MinIO endpoint variable across config, pipeline, scripts, and docs
- pull endpoint from config with env fallback when creating MLflow buckets
- export MLFLOW_S3_ENDPOINT_URL in entrypoint script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c71c0b8a4832d97ff6f008380ed79